### PR TITLE
[OUTLIER] patch redirects and protocol / host determination

### DIFF
--- a/keycloak.js
+++ b/keycloak.js
@@ -105,8 +105,9 @@ function Keycloak (config, keycloakConfig) {
  *  - `admin` Root URL for Keycloak admin callbacks.  Defaults to `/`.
  *
  * @param {Object} options Optional options for specifying details.
+ * @param {Object} keycloakAdapters A hash of adapters for our realms.
  */
-Keycloak.prototype.middleware = function (options) {
+Keycloak.prototype.middleware = function (options, keycloakAdapters) {
   if (!options) {
     options = { logout: '', admin: '' };
   }
@@ -117,10 +118,10 @@ Keycloak.prototype.middleware = function (options) {
   var middlewares = [];
 
   middlewares.push(Setup);
-  middlewares.push(PostAuth(this));
-  middlewares.push(Admin(this, options.admin));
-  middlewares.push(GrantAttacher(this));
-  middlewares.push(Logout(this, options.logout));
+  middlewares.push(PostAuth(keycloakAdapters));
+  middlewares.push(Admin(keycloakAdapters, options.admin));
+  middlewares.push(GrantAttacher(keycloakAdapters));
+  middlewares.push(Logout(keycloakAdapters, options.logout));
 
   return middlewares;
 };

--- a/middleware/admin.js
+++ b/middleware/admin.js
@@ -99,7 +99,7 @@ function adminNotBefore (request, response, keycloak) {
   });
 }
 
-module.exports = function (keycloak, adminUrl) {
+module.exports = function (keycloakAdapters, adminUrl) {
   let url = adminUrl;
   if (url[ url.length - 1 ] !== '/') {
     url = url + '/';
@@ -108,6 +108,10 @@ module.exports = function (keycloak, adminUrl) {
   let urlNotBefore = url + 'k_push_not_before';
 
   return function adminRequest (request, response, next) {
+    const keycloak = request.session.realmInfo && request.session.realmInfo.name ?
+      keycloakAdapters[request.session.realmInfo.name] :
+      keycloakAdapters['Default-Realm'];
+
     switch (request.url) {
       case urlLogout:
         adminLogout(request, response, keycloak);

--- a/middleware/grant-attacher.js
+++ b/middleware/grant-attacher.js
@@ -15,8 +15,12 @@
  */
 'use strict';
 
-module.exports = function (keycloak) {
+module.exports = function (keycloakAdapters) {
   return function grantAttacher (request, response, next) {
+    const keycloak = request.session.realmInfo && request.session.realmInfo.name ?
+      keycloakAdapters[request.session.realmInfo.name] :
+      keycloakAdapters['Default-Realm'];
+
     keycloak.getGrant(request, response)
       .then(grant => {
         request.kauth.grant = grant;

--- a/middleware/logout.js
+++ b/middleware/logout.js
@@ -15,8 +15,12 @@
  */
 'use strict';
 
-module.exports = function (keycloak, logoutUrl) {
+module.exports = function (keycloakAdapters, logoutUrl) {
   return function logout (request, response, next) {
+    const keycloak = request.session.realmInfo && request.session.realmInfo.name ?
+      keycloakAdapters[request.session.realmInfo.name] :
+      keycloakAdapters['Default-Realm'];
+
     if (request.url !== logoutUrl) {
       return next();
     }

--- a/middleware/logout.js
+++ b/middleware/logout.js
@@ -27,12 +27,13 @@ module.exports = function (keycloak, logoutUrl) {
       delete request.kauth.grant;
     }
 
-    let host = request.hostname;
     let headerHost = request.headers.host.split(':');
+    let host = headerHost[0];
     let port = headerHost[1] || '';
-    let redirectUrl = request.protocol + '://' + host + (port === '' ? '' : ':' + port) + '/';
+    let protocol = request.isSecure() ? 'https' : 'http';
+    let redirectUrl = protocol + '://' + host + (port === '' ? '' : ':' + port) + '/saml_redirect';
     let keycloakLogoutUrl = keycloak.logoutUrl(redirectUrl);
 
-    response.redirect(keycloakLogoutUrl);
+    response.redirect(keycloakLogoutUrl, next);
   };
 };

--- a/middleware/post-auth.js
+++ b/middleware/post-auth.js
@@ -17,8 +17,12 @@
 
 const URL = require('url');
 
-module.exports = function (keycloak) {
+module.exports = function (keycloakAdapters) {
   return function postAuth (request, response, next) {
+    const keycloak = request.session.realmInfo && request.session.realmInfo.name ?
+      keycloakAdapters[request.session.realmInfo.name] :
+      keycloakAdapters['Default-Realm'];
+
     if (!request.query.auth_callback) {
       return next();
     }

--- a/middleware/post-auth.js
+++ b/middleware/post-auth.js
@@ -35,7 +35,7 @@ module.exports = function (keycloak) {
     keycloak.getGrantFromCode(request.query.code, request, response)
       .then(grant => {
         let urlParts = {
-          pathname: request.path,
+          pathname: request.path(),
           query: request.query
         };
 
@@ -52,7 +52,7 @@ module.exports = function (keycloak) {
         } catch (err) {
           console.log(err);
         }
-        response.redirect(cleanUrl);
+        response.redirect(cleanUrl, next);
       }).catch((err) => {
         keycloak.accessDenied(request, response, next);
         console.error('Could not obtain grant code: ' + err);

--- a/middleware/protect.js
+++ b/middleware/protect.js
@@ -24,7 +24,7 @@ function forceLogin (keycloak, request, response, next) {
   let protocol = request.isSecure() ? 'https' : 'http';
   let hasQuery = ~(request.originalUrl || request.url).indexOf('?');
 
-  let redirectUrl = protocol + '://' + host + (port === '' ? '' : ':' + port) + '/saml_entry' + (hasQuery ? '&' : '?') + 'auth_callback=1';
+  let redirectUrl = protocol + '://' + host + (port === '' ? '' : ':' + port) + '/saml_callback' + (hasQuery ? '&' : '?') + 'auth_callback=1';
 
   if (request.session) {
     request.session.auth_redirect_uri = redirectUrl;

--- a/middleware/protect.js
+++ b/middleware/protect.js
@@ -24,7 +24,7 @@ function forceLogin (keycloak, request, response, next) {
   let protocol = request.isSecure() ? 'https' : 'http';
   let hasQuery = ~(request.originalUrl || request.url).indexOf('?');
 
-  let redirectUrl = protocol + '://' + host + (port === '' ? '' : ':' + port) + '/saml_callback' + (hasQuery ? '&' : '?') + 'auth_callback=1';
+  let redirectUrl = protocol + '://' + host + (port === '' ? '' : ':' + port) + '/saml_entry' + (hasQuery ? '&' : '?') + 'auth_callback=1';
 
   if (request.session) {
     request.session.auth_redirect_uri = redirectUrl;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "keycloak-connect",
-  "version": "8.0.0-dev",
+  "version": "9.0.0-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2018,9 +2018,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
-      "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -4736,9 +4736,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.8",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.8.tgz",
-      "integrity": "sha512-XhHJ3S3ZyMwP8kY1Gkugqx3CJh2C3O0y8NPiSxtm1tyD/pktLAkFZsFGpuNfTZddKDQ/bbDBLAd2YyA1pbi8HQ==",
+      "version": "3.6.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.9.tgz",
+      "integrity": "sha512-pcnnhaoG6RtrvHJ1dFncAe8Od6Nuy30oaJ82ts6//sGSXOP5UjBMEthiProjXmMNHOfd93sqlkztifFMcb+4yw==",
       "dev": true,
       "optional": true,
       "requires": {


### PR DESCRIPTION
Since we use Restify, and not Express, any calls to `redirect` require that you pass next. Additionally, the way you determine the protocol and host is slightly different between frameworks. Finally, the middleware doesn't know which realm it should be hitting when the app first boots, so it needed to be given a hash of adapters so it can choose depending on the realm it's hitting.