### PR TITLE
Use X-Forwarded-Proto Header to Determine Protocol of redirectUrl

### DIFF
--- a/middleware/protect.js
+++ b/middleware/protect.js
@@ -21,7 +21,7 @@ function forceLogin (keycloak, request, response, next) {
   let headerHost = request.headers.host.split(':');
   let host = headerHost[0];
   let port = headerHost[1] || '';
-  let protocol = request.isSecure() ? 'https' : 'http';
+  let protocol = request.headers['x-forwarded-proto'] || (request.isSecure() ? 'https' : 'http');
   let hasQuery = ~(request.originalUrl || request.url).indexOf('?');
 
   let redirectUrl = protocol + '://' + host + (port === '' ? '' : ':' + port) + '/saml_callback' + (hasQuery ? '&' : '?') + 'auth_callback=1';


### PR DESCRIPTION
Previously we were relying on the restify method `isSecure` but this doesn't work because it just checks if the connection is encrypted and once http traffic gets past the loader balancer it becomes unencrypted in our internal network. Instead we need to check the `x-forwarded-proto` header so we can see what the protocol of the request was when it got to the loader balancer. This code accounts for that.