### PR TITLE
Use Backend URL instead of Front-End URL

### DIFF
--- a/middleware/auth-utils/config.js
+++ b/middleware/auth-utils/config.js
@@ -100,6 +100,10 @@ Config.prototype.configure = function configure (config) {
    */
   this.realm = resolveValue(config.realm || config.realm);
 
+  this.backendUrl = 'http://keycloak.outlier/auth';
+
+  this.backendRealmUrl = this.backendUrl + '/realms/' + this.realm;
+
   /**
    * Client/Application ID
    * @type {String}

--- a/middleware/auth-utils/grant-manager.js
+++ b/middleware/auth-utils/grant-manager.js
@@ -281,7 +281,7 @@ GrantManager.prototype.validateAccessToken = function validateAccessToken (token
 
 GrantManager.prototype.userInfo = function userInfo (token, callback) {
   // TODO: we need to use the backend URL here, not frontend
-  const url = this.realmUrl + '/protocol/openid-connect/userinfo';
+  const url = this.backendRealmUrl + '/protocol/openid-connect/userinfo';
   const options = URL.parse(url);
   options.method = 'GET';
 
@@ -487,7 +487,7 @@ const validationHandler = (manager, token) => (resolve, reject, json) => {
 };
 
 const postOptions = (manager, path) => {
-  // TODO: we need to use the backend URL here, not frontend
+  // TODO: we need to use the backend URL here, not frontend, should be taken care of by the calling function
   const realPath = path || '/protocol/openid-connect/token';
   const opts = URL.parse(manager.realmUrl + realPath);
   opts.headers = {


### PR DESCRIPTION
We are trying to shut down as many publicly available endpoints as possible and expose only what we need. This allows us to make internal calls without having to expose the `/token` endpoint or `userinfo`.